### PR TITLE
UPDATE .vim*: make better ESC 'jk' less time delay

### DIFF
--- a/.vimkeymap
+++ b/.vimkeymap
@@ -27,5 +27,6 @@ nnoremap U <C-r>
 map <C-s> A;<ESC>
 
 "Map jk to ESC
-inoremap jk <ESC>
+let g:better_escape_interval = 200
+let g:better_escape_shortcut = 'jk'
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/.vimrc
+++ b/.vimrc
@@ -38,6 +38,7 @@ Plug 'jiangmiao/auto-pairs'
 Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
 Plug 'tpope/vim-fugitive'
+Plug 'jdhao/better-escape.vim'
 "Language pack for vim
 Plug 'sheerun/vim-polyglot'
 "Autocomplete for vim


### PR DESCRIPTION
I think this plugin can be help you map 'jk' to escape easier 
Link plugin: https://github.com/jdhao/better-escape.vim